### PR TITLE
W-14403593 | Added JavaVersionSupport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <name>Json Module</name>
 
     <properties>
+        <mule.sdk.api.version>0.6.0</mule.sdk.api.version>
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.2</jackson.databind.version>
         <json.schema.validation.version>2.2.14</json.schema.validation.version>
@@ -29,7 +30,8 @@
         <settings.file>${java.io.tmpdir}/effective-settings.xml</settings.file>
         <munit.version>3.1.0-SNAPSHOT</munit.version>
         <mtf.tools.version>1.2.0-SNAPSHOT</mtf.tools.version>
-        <file.connector.version>1.5.1</file.connector.version>
+        <file.connector.version>2.0.0-SNAPSHOT</file.connector.version>
+        <munit.extensions.maven.plugin.version>1.2.0-SNAPSHOT</munit.extensions.maven.plugin.version>
         <mtf.javaopts></mtf.javaopts>
         <jacoco.version>0.8.10</jacoco.version>
         <mulesoftLicenseVersion>1.4.0</mulesoftLicenseVersion>
@@ -42,6 +44,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.mule.sdk</groupId>
+            <artifactId>mule-sdk-api</artifactId>
+            <version>${mule.sdk.api.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -203,7 +210,7 @@
             <plugin>
                 <groupId>com.mulesoft.munit</groupId>
                 <artifactId>munit-extensions-maven-plugin</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>${munit.extensions.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>test</id>

--- a/src/main/java/org/mule/module/json/internal/JsonModule.java
+++ b/src/main/java/org/mule/module/json/internal/JsonModule.java
@@ -11,7 +11,11 @@ import org.mule.runtime.extension.api.annotation.Extension;
 import org.mule.runtime.extension.api.annotation.Operations;
 import org.mule.runtime.extension.api.annotation.dsl.xml.Xml;
 import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
+import org.mule.sdk.api.annotation.JavaVersionSupport;
 
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_11;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_17;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_8;
 
 /**
  * The JSON module contains tools to help you deal with JSON documents
@@ -20,6 +24,7 @@ import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
 @Extension(name = "JSON")
 @ErrorTypes(JsonError.class)
 @Operations(ValidateJsonSchemaOperation.class)
+@JavaVersionSupport({JAVA_8, JAVA_11, JAVA_17})
 public class JsonModule {
 
 }


### PR DESCRIPTION
These changes add the `JavaVersionSupport` annotation.

Note that the tests are still failing due to an unrelated issue with the `File` connector.

```
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
java.lang.AssertionError: The error ID thrown does not match the expected one.  expected:<[JSON:INVALID_INPUT_JSO]N> but was:<[MULE:UNKNOW]N>
	at org.mule.munit.runner.flow.TestFlow.run(TestFlow.java:313)
Caused by: org.mule.runtime.api.exception.MuleRuntimeException: Unexpected error reading file '/Users/ababei/Desktop/mulesoft/mule-json-module/src/test/resources/inputs/bad-object.json': Cannot resolve ambiguous delegation of public long java.io.InputStream.transferTo(java.io.OutputStream) throws java.io.IOException to public synchronized int java.io.BufferedInputStream.read() throws java.io.IOException or public synchronized int java.io.BufferedInputStream.available() throws java.io.IOException
Caused by: java.lang.IllegalArgumentException: Cannot resolve ambiguous delegation of public long java.io.InputStream.transferTo(java.io.OutputStream) throws java.io.IOException to public synchronized int java.io.BufferedInputStream.read() throws java.io.IOException or public synchronized int java.io.BufferedInputStream.available() throws java.io.IOException
	at net.bytebuddy.implementation.bind.MethodDelegationBinder$BindingResolver$Default.doResolve(MethodDelegationBinder.java:639)
	at net.bytebuddy.implementation.bind.MethodDelegationBinder$BindingResolver$Default.doResolve(MethodDelegationBinder.java:653)
	at net.bytebuddy.implementation.bind.MethodDelegationBinder$BindingResolver$Default.doResolve(MethodDelegationBinder.java:653)
	at net.bytebuddy.implementation.bind.MethodDelegationBinder$BindingResolver$Default.resolve(MethodDelegationBinder.java:614)
	at net.bytebuddy.implementation.bind.MethodDelegationBinder$Processor.bind(MethodDelegationBinder.java:1101)
	at net.bytebuddy.implementation.MethodDelegation$Appender.apply(MethodDelegation.java:1349)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyCode(TypeWriter.java:730)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyBody(TypeWriter.java:715)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod.apply(TypeWriter.java:622)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForCreation.create(TypeWriter.java:6043)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2224)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4050)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3734)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$Delegator.make(DynamicType.java:3986)
	at org.mule.extension.file.common.api.stream.AbstractFileInputStream.getInputStreamFromStreamFactory(AbstractFileInputStream.java:60)
	at org.mule.extension.file.common.api.stream.AbstractNonFinalizableFileInputStream.createLazyStream(AbstractNonFinalizableFileInputStream.java:44)
	at org.mule.extension.file.common.api.stream.AbstractNonFinalizableFileInputStream.<init>(AbstractNonFinalizableFileInputStream.java:56)
	at org.mule.extension.file.common.api.stream.AbstractNonFinalizableFileInputStream.<init>(AbstractNonFinalizableFileInputStream.java:52)
	at org.mule.extension.file.internal.FileInputStream.<init>(FileInputStream.java:60)
	at org.mule.extension.file.internal.command.LocalReadCommand.read(LocalReadCommand.java:104)
	at org.mule.extension.file.internal.command.LocalReadCommand.read(LocalReadCommand.java:65)
	at org.mule.extension.file.common.api.AbstractFileSystem.read(AbstractFileSystem.java:145)
	at org.mule.extension.file.common.api.BaseFileSystemOperations.doRead(BaseFileSystemOperations.java:253)
	at org.mule.extension.file.internal.FileOperations.read(FileOperations.java:131)
	at org.mule.extension.file.internal.FileOperations$read$MethodComponentExecutor_mule_json_module_test_application.execute(Unknown Source)
```