### PR TITLE
W-14775713 | Java 17 runtime compatibility changes

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,105 @@
+# Salesforce Open Source Community Code of Conduct
+
+## About the Code of Conduct
+
+Equality is a core value at Salesforce. We believe a diverse and inclusive
+community fosters innovation and creativity, and are committed to building a
+culture where everyone feels included.
+
+Salesforce open-source projects are committed to providing a friendly, safe, and
+welcoming environment for all, regardless of gender identity and expression,
+sexual orientation, disability, physical appearance, body size, ethnicity, nationality, 
+race, age, religion, level of experience, education, socioeconomic status, or 
+other similar personal characteristics.
+
+The goal of this code of conduct is to specify a baseline standard of behavior so
+that people with different social values and communication styles can work
+together effectively, productively, and respectfully in our open source community.
+It also establishes a mechanism for reporting issues and resolving conflicts.
+
+All questions and reports of abusive, harassing, or otherwise unacceptable behavior
+in a Salesforce open-source project may be reported by contacting the Salesforce
+Open Source Conduct Committee at ossconduct@salesforce.com.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of gender 
+identity and expression, sexual orientation, disability, physical appearance, 
+body size, ethnicity, nationality, race, age, religion, level of experience, education, 
+socioeconomic status, or other similar personal characteristics.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy toward other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Personal attacks, insulting/derogatory comments, or trolling
+* Public or private harassment
+* Publishing, or threatening to publish, others' private information—such as
+a physical or electronic address—without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+professional setting
+* Advocating for or encouraging any of the above behaviors
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned with this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project email
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the Salesforce Open Source Conduct Committee 
+at ossconduct@salesforce.com. All complaints will be reviewed and investigated 
+and will result in a response that is deemed necessary and appropriate to the 
+circumstances. The committee is obligated to maintain confidentiality with 
+regard to the reporter of an incident. Further details of specific enforcement 
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership and the Salesforce Open Source Conduct 
+Committee.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][contributor-covenant-home],
+version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html. 
+It includes adaptions and additions from [Go Community Code of Conduct][golang-coc], 
+[CNCF Code of Conduct][cncf-coc], and [Microsoft Open Source Code of Conduct][microsoft-coc].
+
+This Code of Conduct is licensed under the [Creative Commons Attribution 3.0 License][cc-by-3-us].
+
+[contributor-covenant-home]: https://www.contributor-covenant.org (https://www.contributor-covenant.org/)
+[golang-coc]: https://golang.org/conduct
+[cncf-coc]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[microsoft-coc]: https://opensource.microsoft.com/codeofconduct/
+[cc-by-3-us]: https://creativecommons.org/licenses/by/3.0/us/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,492 +1,181 @@
-Mule Runtime is distributed under the terms of the Common Public Attribution 
-License (CPAL), whose definition follows below.  For information on the license
-type for each third-party software product used by Mule, refer to 
-https://developer.mulesoft.com/docs/display/current/Third-Party+Software+In+Mule
-
-
-Common Public Attribution License Version 1.0 (CPAL)
-
-
-1. "Definitions"
-
-1.0.1 "Commercial Use" means distribution or otherwise making the Covered
-Code available to a third party.
-
-1.1 "Contributor" means each entity that creates or contributes to the creation
-of Modifications.
-
-1.2 "Contributor Version" means the combination of the Original Code, prior
-Modifications used by a Contributor, and the Modifications made by that
-particular Contributor.
-
-1.3 "Covered Code" means the Original Code or Modifications or the combination
-of the Original Code and Modifications, in each case including portions
-thereof.
-
-1.4 "Electronic Distribution Mechanism" means a mechanism generally accepted in
-the software development community for the electronic transfer of data.
-
-1.5 "Executable" means Covered Code in any form other than Source Code.
-
-1.6 "Initial Developer" means the individual or entity identified as the Initial
-Developer in the Source Code notice required by Exhibit A.
-
-1.7 "Larger Work" means a work which combines Covered Code or portions thereof
-with code not governed by the terms of this License.
-
-1.8 "License" means this document.
-
-1.8.1 "Licensable" means having the right to grant, to the maximum extent
-possible, whether at the time of the initial grant or subsequently acquired, any
-and all of the rights conveyed herein.
-
-1.9 "Modifications" means any addition to or deletion from the substance or
-structure of either the Original Code or any previous Modifications. When
-Covered Code is released as a series of files, a Modification is:
-
-A. Any addition to or deletion from the contents of a file containing Original
-Code or previous Modifications.
-
-B. Any new file that contains any part of the Original Code or previous
-Modifications.
-
-1.10 "Original Code" means Source Code of computer software code which is
-described in the Source Code notice required by Exhibit A as Original Code, and
-which, at the time of its release under this License is not already Covered Code
-governed by this License.
-
-1.10.1 "Patent Claims" means any patent claim(s), now owned or hereafter
-acquired, including without limitation, method, process, and apparatus claims,
-in any patent Licensable by grantor.
-
-1.11 "Source Code" means the preferred form of the Covered Code for making
-modifications to it, including all modules it contains, plus any associated
-interface definition files, scripts used to control compilation and installation
-of an Executable, or source code differential comparisons against either the
-Original Code or another well known, available Covered Code of the Contributor's
-choice. The Source Code can be in a compressed or archival form, provided the
-appropriate decompression or de-archiving software is widely available for no
-charge.
-
-1.12 "You" (or "Your") means an individual or a legal entity exercising
-rights under, and complying with all of the terms of, this License or a future
-version of this License issued under Section 6.1. For legal entities, "You"
-includes any entity which controls, is controlled by, or is under common control
-with You. For purposes of this definition, "control" means (a) the power, direct
-or indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or (b) ownership of more than fifty percent (50%) of the
-outstanding shares or beneficial ownership of such entity.
-
-2. Source Code License.
-
-2.1 The Initial Developer Grant.
-The Initial Developer hereby grants You a world-wide, royalty-free,
-non-exclusive license, subject to third party intellectual property claims:
-
-(a) under intellectual property rights (other than patent or trademark)
-Licensable by Initial Developer to use, reproduce, modify, display, perform,
-sublicense and distribute the Original Code (or portions thereof) with or
-without Modifications, and/or as part of a Larger Work; and
-
-(b) under Patents Claims infringed by the making, using or selling of
-Original Code, to make, have made, use, practice, sell, and offer for sale,
-and/or otherwise dispose of the Original Code (or portions thereof).
-
-(c) the licenses granted in this Section 2.1(a) and (b) are effective on the
-date Initial Developer first distributes Original Code under the terms of this
-License.
-
-(d) Notwithstanding Section 2.1(b) above, no patent license is granted: 1)
-for code that You delete from the Original Code; 2) separate from the Original
-Code; or 3) for infringements caused by: i) the modification of the Original
-Code or ii) the combination of the Original Code with other software or
-devices.
-
-2.2 Contributor Grant.
-
-Subject to third party intellectual property claims, each Contributor hereby
-grants You a world-wide, royalty-free, non-exclusive license
-
-(a) under intellectual property rights (other than patent or trademark)
-Licensable by Contributor, to use, reproduce, modify, display, perform,
-sublicense and distribute the Modifications created by such Contributor (or
-portions thereof) either on an unmodified basis, with other Modifications, as
-Covered Code and/or as part of a Larger Work; and
-
-(b) under Patent Claims infringed by the making, using, or selling of
-Modifications made by that Contributor either alone and/or in combination with
-its Contributor Version (or portions of such combination), to make, use, sell,
-offer for sale, have made, and/or otherwise dispose of: 1) Modifications made
-by that Contributor (or portions thereof); and 2) the combination of
-Modifications made by that Contributor with its Contributor Version (or portions
-of such combination).
-
-(c) the licenses granted in Sections 2.2(a) and 2.2(b) are effective on the
-date Contributor first makes Commercial Use of the Covered Code.
-
-(d) Notwithstanding Section 2.2(b) above, no patent license is granted: 1)
-for any code that Contributor has deleted from the Contributor Version; 2)
-separate from the Contributor Version; 3) for infringements caused by: i) third
-party modifications of Contributor Version or ii) the combination of
-Modifications made by that Contributor with other software (except as part of
-the Contributor Version) or other devices; or 4) under Patent Claims infringed
-by Covered Code in the absence of Modifications made by that Contributor.
-
-3. Distribution Obligations.
-
-3.1 Application of License.
-The Modifications which You create or to which You contribute are governed by
-the terms of this License, including without limitation Section 2.2. The Source
-Code version of Covered Code may be distributed only under the terms of this
-License or a future version of this License released under Section 6.1, and You
-must include a copy of this License with every copy of the Source Code You
-distribute. You may not offer or impose any terms on any Source Code version
-that alters or restricts the applicable version of this License or the
-recipients' rights hereunder. However, You may include an additional document
-offering the additional rights described in Section 3.5.
-
-3.2 Availability of Source Code.
-Any Modification which You create or to which You contribute must be made
-available in Source Code form under the terms of this License either on the same
-media as an Executable version or via an accepted Electronic Distribution
-Mechanism to anyone to whom you made an Executable version available; and if
-made available via Electronic Distribution Mechanism, must remain available for
-at least twelve (12) months after the date it initially became available, or at
-least six (6) months after a subsequent version of that particular Modification
-has been made available to such recipients. You are responsible for ensuring
-that the Source Code version remains available even if the Electronic
-Distribution Mechanism is maintained by a third party.
-
-3.3 Description of Modifications.
-You must cause all Covered Code to which You contribute to contain a file
-documenting the changes You made to create that Covered Code and the date of any
-change. You must include a prominent statement that the Modification is
-derived, directly or indirectly, from Original Code provided by the Initial
-Developer and including the name of the Initial Developer in (a) the Source
-Code, and (b) in any notice in an Executable version or related documentation in
-which You describe the origin or ownership of the Covered Code.
-
-3.4 Intellectual Property Matters
-
-(a) Third Party Claims.
-If Contributor has knowledge that a license under a third party's intellectual
-property rights is required to exercise the rights granted by such Contributor
-under Sections 2.1 or 2.2, Contributor must include a text file with the Source
-Code distribution titled "LEGAL" which describes the claim and the party making
-the claim in sufficient detail that a recipient will know whom to contact. If
-Contributor obtains such knowledge after the Modification is made available as
-described in Section 3.2, Contributor shall promptly modify the LEGAL file in
-all copies Contributor makes available thereafter and shall take other steps
-(such as notifying appropriate mailing lists or newsgroups) reasonably
-calculated to inform those who received the Covered Code that new knowledge has
-been obtained.
-
-(b) Contributor APIs.
-If Contributor's Modifications include an application programming interface and
-Contributor has knowledge of patent licenses which are reasonably necessary to
-implement that API, Contributor must also include this information in the LEGAL
-file.
-
-(c) Representations.
-Contributor represents that, except as disclosed pursuant to Section 3.4(a)
-above, Contributor believes that Contributor's Modifications are Contributor's
-original creation(s) and/or Contributor has sufficient rights to grant the
-rights conveyed by this License.
-
-3.5 Required Notices.
-You must duplicate the notice in Exhibit A in each file of the Source Code. If
-it is not possible to put such notice in a particular Source Code file due to
-its structure, then You must include such notice in a location (such as a
-relevant directory) where a user would be likely to look for such a notice. If
-You created one or more Modification(s) You may add your name as a Contributor
-to the notice described in Exhibit A. You must also duplicate this License in
-any documentation for the Source Code where You describe recipients' rights or
-ownership rights relating to Covered Code. You may choose to offer, and to
-charge a fee for, warranty, support, indemnity or liability obligations to one
-or more recipients of Covered Code. However, You may do so only on Your own
-behalf, and not on behalf of the Initial Developer or any Contributor. You must
-make it absolutely clear than any such warranty, support, indemnity or liability
-obligation is offered by You alone, and You hereby agree to indemnify the
-Initial Developer and every Contributor for any liability incurred by the
-Initial Developer or such Contributor as a result of warranty, support,
-indemnity or liability terms You offer.
-
-3.6 Distribution of Executable Versions.
-You may distribute Covered Code in Executable form only if the requirements of
-Section 3.1-3.5 have been met for that Covered Code, and if You include a notice
-stating that the Source Code version of the Covered Code is available under the
-terms of this License, including a description of how and where You have
-fulfilled the obligations of Section 3.2. The notice must be conspicuously
-included in any notice in an Executable version, related documentation or
-collateral in which You describe recipients' rights relating to the Covered
-Code. You may distribute the Executable version of Covered Code or ownership
-rights under a license of Your choice, which may contain terms different from
-this License, provided that You are in compliance with the terms of this License
-and that the license for the Executable version does not attempt to limit or
-alter the recipient's rights in the Source Code version from the rights set
-forth in this License. If You distribute the Executable version under a
-different license You must make it absolutely clear that any terms which differ
-from this License are offered by You alone, not by the Initial Developer,
-Original Developer or any Contributor. You hereby agree to indemnify the
-Initial Developer, Original Developer and every Contributor for any liability
-incurred by the Initial Developer, Original Developer or such Contributor as a
-result of any such terms You offer.
-
-3.7 Larger Works.
-You may create a Larger Work by combining Covered Code with other code not
-governed by the terms of this License and distribute the Larger Work as a single
-product. In such a case, You must make sure the requirements of this License are
-fulfilled for the Covered Code.
-
-4. Inability to Comply Due to Statute or Regulation.
-If it is impossible for You to comply with any of the terms of this License with
-respect to some or all of the Covered Code due to statute, judicial order, or
-regulation then You must: (a) comply with the terms of this License to the
-maximum extent possible; and (b) describe the limitations and the code they
-affect. Such description must be included in the LEGAL file described in
-Section 3.4 and must be included with all distributions of the Source Code.
-Except to the extent prohibited by statute or regulation, such description must
-be sufficiently detailed for a recipient of ordinary skill to be able to
-understand it.
-
-5. Application of this License.
-This License applies to code to which the Initial Developer has attached the
-notice in Exhibit A and to related Covered Code.
-
-6. Versions of the License.
-
-6.1 New Versions.
-MuleSoft, Inc. ("MuleSoft") may publish revised and/or new versions of the
-License from time to time. Each version will be given a distinguishing version
-number.
-
-6.2 Effect of New Versions.
-Once Covered Code has been published under a particular version of the License,
-You may always continue to use it under the terms of that version. You may also
-choose to use such Covered Code under the terms of any subsequent version of the
-License published by MuleSoft. No one other than MuleSoft has the right to
-modify the terms applicable to Covered Code created under this License.
-
-6.3 Derivative Works.
-If You create or use a modified version of this License (which you may only do
-in order to apply it to code which is not already Covered Code governed by this
-License), You must (a) rename Your license so that the phrases "MuleSoft",
-"CPAL" or any confusingly similar phrase do not appear in your license (except
-to note that your license differs from this License) and (b) otherwise make it
-clear that Your version of the license contains terms which differ from the
-CPAL. (Filling in the name of the Initial Developer, Original Developer,
-Original Code or Contributor in the notice described in Exhibit A shall not of
-themselves be deemed to be modifications of this License.)
-
-7. DISCLAIMER OF WARRANTY.
-COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT
-WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT
-LIMITATION, WARRANTIES THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE,
-FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE
-QUALITY AND PERFORMANCE OF THE COVERED CODE IS WITH YOU. SHOULD ANY COVERED CODE
-PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL DEVELOPER, ORIGINAL
-DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING,
-REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART
-OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
-THIS DISCLAIMER.
-
-8. TERMINATION.
-
-8.1 This License and the rights granted hereunder will terminate automatically
-if You fail to comply with terms herein and fail to cure such breach within 30
-days of becoming aware of the breach. All sublicenses to the Covered Code which
-are properly granted shall survive any termination of this License. Provisions
-which, by their nature, must remain in effect beyond the termination of this
-License shall survive.
-
-8.2 If You initiate litigation by asserting a patent infringement claim
-(excluding declatory judgment actions) against Initial Developer, Original
-Developer or a Contributor (the Initial Developer, Original Developer or
-Contributor against whom You file such action is referred to as "Participant")
-alleging that:
-
-(a) such Participant's Contributor Version directly or indirectly infringes
-any patent, then any and all rights granted by such Participant to You under
-Sections 2.1 and/or 2.2 of this License shall, upon 60 days notice from
-Participant terminate prospectively, unless if within 60 days after receipt of
-notice You either: (i) agree in writing to pay Participant a mutually agreeable
-reasonable royalty for Your past and future use of Modifications made by such
-Participant, or (ii) withdraw Your litigation claim with respect to the
-Contributor Version against such Participant. If within 60 days of notice, a
-reasonable royalty and payment arrangement are not mutually agreed upon in
-writing by the parties or the litigation claim is not withdrawn, the rights
-granted by Participant to You under Sections 2.1 and/or 2.2 automatically
-terminate at the expiration of the 60 day notice period specified above.
-
-(b) any software, hardware, or device, other than such Participant's
-Contributor Version, directly or indirectly infringes any patent, then any
-rights granted to You by such Participant under Sections 2.1(b) and 2.2(b) are
-revoked effective as of the date You first made, used, sold, distributed, or had
-made, Modifications made by that Participant.
-
-8.3 If You assert a patent infringement claim against Participant alleging that
-such Participant's Contributor Version directly or indirectly infringes any
-patent where such claim is resolved (such as by license or settlement) prior to
-the initiation of patent infringement litigation, then the reasonable value of
-the licenses granted by such Participant under Sections 2.1 or 2.2 shall be
-taken into account in determining the amount or value of any payment or
-license.
-
-8.4 In the event of termination under Sections 8.1 or 8.2 above, all end user
-license agreements (excluding distributors and resellers) which have been
-validly granted by You or any distributor hereunder prior to termination shall
-survive termination.
-
-9. LIMITATION OF LIABILITY.
-UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING
-NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE INITIAL DEVELOPER, ORIGINAL
-DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED CODE, OR ANY
-SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY INDIRECT,
-SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING,
-WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER
-FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN
-IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS
-LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
-INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW
-PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR
-LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND
-LIMITATION MAY NOT APPLY TO YOU.
-
-10. U.S. GOVERNMENT END USERS.
-The Covered Code is a "commercial item," as that term is defined in 48 C.F.R.
-2.101 (Oct. 1995), consisting of "commercial computer software" and "commercial
-computer software documentation," as such terms are used in 48 C.F.R. 12.212
-(Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1 through
-227.7202-4 (June 1995), all U.S. Government End Users acquire Covered Code with
-only those rights set forth herein.
-
-11. MISCELLANEOUS.
-This License represents the complete agreement concerning subject matter hereof.
-If any provision of this License is held to be unenforceable, such provision
-shall be reformed only to the extent necessary to make it enforceable. This
-License shall be governed by California law provisions (except to the extent
-applicable law, if any, provides otherwise), excluding its conflict-of-law
-provisions. With respect to disputes in which at least one party is a citizen
-of, or an entity chartered or registered to do business in the United States of
-America, any litigation relating to this License shall be subject to the
-jurisdiction of the Federal Courts of the Northern District of California, with
-venue lying in Santa Clara County, California, with the losing party responsible
-for costs, including without limitation, court costs and reasonable attorneys'
-fees and expenses. The application of the United Nations Convention on Contracts
-for the International Sale of Goods is expressly excluded. Any law or
-regulation which provides that the language of a contract shall be construed
-against the drafter shall not apply to this License.
-
-12. RESPONSIBILITY FOR CLAIMS.
-As between Initial Developer, Original Developer and the Contributors, each
-party is responsible for claims and damages arising, directly or indirectly, out
-of its utilization of rights under this License and You agree to work with
-Initial Developer, Original Developer and Contributors to distribute such
-responsibility on an equitable basis. Nothing herein is intended or shall be
-deemed to constitute any admission of liability.
-
-13. MULTIPLE-LICENSED CODE.
-Initial Developer may designate portions of the Covered Code as
-Multiple-Licensed. Multiple-Licensed means that the Initial Developer permits
-you to utilize portions of the Covered Code under Your choice of the CPAL or the
-alternative licenses, if any, specified by the Initial Developer in the file
-described in Exhibit A.
-
-14. ADDITIONAL TERM: ATTRIBUTION
-
-(a) As a modest attribution to the organizer of the development of the
-Original Code ("Original Developer"), in the hope that its promotional value may
-help justify the time, money and effort invested in writing the Original Code,
-the Original Developer may include in Exhibit B ("Attribution Information") a
-requirement that each time an Executable and Source Code or a Larger Work is
-launched or initially run (which includes initiating a session), a prominent
-display of the Original Developer's Attribution Information (as defined below)
-must occur on the graphic user interface employed by the end user to access such
-Covered Code (which may include display on a splash screen), if any. The size
-of the graphic image should be consistent with the size of the other elements of
-the Attribution Information. If the access by the end user to the Executable and
-Source Code does not create a graphic user interface for access to the Covered
-Code, this obligation shall not apply. If the Original Code displays such
-Attribution Information in a particular form (such as in the form of a splash
-screen, notice at login, an "about" display, or dedicated attribution area on
-user interface screens), continued use of such form for that Attribution
-Information is one way of meeting this requirement for notice.
-
-(b) Attribution information may only include a copyright notice, a brief
-phrase, graphic image and a URL ("Attribution Information") and is subject to
-the Attribution Limits as defined below. For these purposes, prominent shall
-mean display for sufficient duration to give reasonable notice to the user of
-the identity of the Original Developer and that if You include Attribution
-Information or similar information for other parties, You must ensure that the
-Attribution Information for the Original Developer shall be no less prominent
-than such Attribution Information or similar information for the other party.
-For greater certainty, the Original Developer may choose to specify in Exhibit B
-below that the above attribution requirement only applies to an Executable and
-Source Code resulting from the Original Code or any Modification, but not a
-Larger Work. The intent is to provide for reasonably modest attribution,
-therefore the Original Developer cannot require that You display, at any time,
-more than the following information as Attribution Information: (a) a copyright
-notice including the name of the Original Developer; (b) a word or one phrase
-(not exceeding 10 words); (c) one graphic image provided by the Original
-Developer; and (d) a URL (collectively, the "Attribution Limits").
-
-(c) If Exhibit B does not include any Attribution Information, then there
-are no requirements for You to display any Attribution Information of the
-Original Developer.
-
-(d) You acknowledge that all trademarks, service marks and/or trade names
-contained within the Attribution Information distributed with the Covered Code
-are the exclusive property of their owners and may only be used with the
-permission of their owners, or under circumstances otherwise permitted by law or
-as expressly set out in this License.
-
-15. ADDITIONAL TERM: NETWORK USE.
-The term "External Deployment" means the use, distribution, or communication of
-the Original Code or Modifications in any way such that the Original Code or
-Modifications may be used by anyone other than You, whether those works are
-distributed or communicated to those persons or made available as an application
-intended for use over a network. As an express condition for the grants of
-license hereunder, You must treat any External Deployment by You of the Original
-Code or Modifications as a distribution under section 3.1 and make Source Code
-available under Section 3.2.
-
-
-EXHIBIT A. Common Public Attribution License Version 1.0.
-"The contents of this file are subject to the Common Public Attribution License
-Version 1.0 (the "License"); you may not use this file except in compliance with
-the License. You may obtain a copy of the License at
-http://www.MuleSoft.com/CPAL/. The License is based on the Mozilla Public
-License Version 1.1 but Sections 14 and 15 have been added to cover use of
-software over a computer network and provide for limited attribution for the
-Original Developer. In addition, Exhibit A has been modified to be consistent
-with Exhibit B.
-Software distributed under the License is distributed on an "AS IS" basis,
-WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
-specific language governing rights and limitations under the License.
-The Original Code is MuleSoft Mule
-The Initial Developer of the Original Code is MuleSoft Inc. All portions of
-the code are Copyright (c) 2003-2015 MuleSoft Inc. All Rights Reserved.
-
-EXHIBIT B. Attribution Information
-Subject to the limitations and other requirements in Section 14 of the License,
-the Original Developer requires You to display the following Attribution
-Information:
-
-Attribution Copyright Notice: Copyright (c) 2003-2015 MuleSoft Inc.
-Attribution Phrase (not exceeding 10 words): Powered by Mule. MuleSoft is Open
-for Integration.
-Attribution URL: http://www.MuleSoft.com
-Graphic Image provided in the Covered Code as file:
-http://www.MuleSoft.com/images/mulesoft-logo.gif
-
-
-Redistributions of the Covered Code in binary form or source code form, must
-ensure that the first time the resulting executable program is launched, a user
-interface, if any, shall include the attribution information set forth below
-prominently. If the executable program does not launch a user interface, the
-Company name and URL shall be included in the notice section of each file of the
-Covered Code. :
-
-Display of Attribution Information is required in Larger Works which are defined
-in the CPAL as a work which combines Covered Code or portions thereof with code
-not governed by the terms of the CPAL.
+Apache License Version 2.0
+
+Copyright (c) 2024 Salesforce, Inc.
+All rights reserved.
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/LICENSE_HEADER.txt
+++ b/LICENSE_HEADER.txt
@@ -1,0 +1,14 @@
+Copyright (c) 2024, Salesforce, Inc.
+SPDX-License-Identifier: Apache-2
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+## Security
+
+Please report any security issue to [security@salesforce.com](mailto:security@salesforce.com)
+as soon as it is discovered. This library limits its runtime dependencies in
+order to reduce the total cost of ownership as much as can be, but all consumers
+should remain vigilant and have their security stakeholders review all third-party
+products (3PP) like this one and their dependencies.

--- a/mule-shaders-module/pom.xml
+++ b/mule-shaders-module/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mule.modules</groupId>
+    <artifactId>mule-shaders-module</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>Shader Utilities Module</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <javaVersion>1.8</javaVersion>
+        <mule.extensions.shade.plugin.version>1.0.4</mule.extensions.shade.plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mule.runtime.plugins</groupId>
+            <artifactId>mule-extensions-shade-plugin</artifactId>
+            <version>${mule.extensions.shade.plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>mule-plugin</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>mule-plugin</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessClassRemapper.java
+++ b/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessClassRemapper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mule.module.shaders.api;
+
+import org.apache.maven.plugins.shade.resource.ResourceTransformer;
+import org.mule.module.shaders.api.ReflectiveAccessShaderTransformer.ClassMember;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.Remapper;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Changes the specified class members to be accessible via reflection at runtime.
+ */
+public class ReflectiveAccessClassRemapper extends ClassRemapper {
+
+  private static final char PACKAGE_SEPARATOR = '.';
+  private static final char PATH_SEPARATOR = '/';
+  private static final char INNER_CLASS_SEPARATOR = '$';
+  private final List<ClassMember> configuredMembers;
+
+  public ReflectiveAccessClassRemapper(ClassVisitor classVisitor, Remapper remapper, List<ResourceTransformer> transformers) {
+    super(classVisitor, remapper);
+    this.configuredMembers = transformers.stream()
+        .filter(ReflectiveAccessShaderTransformer.class::isInstance)
+        .map(ReflectiveAccessShaderTransformer.class::cast)
+        .map(ReflectiveAccessShaderTransformer::getMembers)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+    int effectiveAccess = isFieldConfigured(name) ? toAccessible(access) : access;
+    return super.visitField(effectiveAccess, name, descriptor, signature, value);
+  }
+
+  private boolean isFieldConfigured(String fieldName) {
+    return this.configuredMembers.stream()
+        .anyMatch(member -> member.equals(toCanonicalName(this.className), fieldName));
+  }
+
+  private static int toAccessible(int access) {
+    return (access & ~Opcodes.ACC_FINAL & ~Opcodes.ACC_PRIVATE & ~Opcodes.ACC_PROTECTED) | Opcodes.ACC_PUBLIC;
+  }
+
+  private static String toCanonicalName(String resourceName) {
+    return Optional.ofNullable(resourceName)
+        .map(name -> name.replace(PATH_SEPARATOR, PACKAGE_SEPARATOR))
+        .map(name -> name.replace(INNER_CLASS_SEPARATOR, PACKAGE_SEPARATOR))
+        .orElse(null);
+  }
+}

--- a/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessShader.java
+++ b/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessShader.java
@@ -1,0 +1,641 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mule.module.shaders.api;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.shade.ShadeRequest;
+import org.apache.maven.plugins.shade.Shader;
+import org.apache.maven.plugins.shade.filter.Filter;
+import org.apache.maven.plugins.shade.relocation.Relocator;
+import org.apache.maven.plugins.shade.resource.ManifestResourceTransformer;
+import org.apache.maven.plugins.shade.resource.ReproducibleResourceTransformer;
+import org.apache.maven.plugins.shade.resource.ResourceTransformer;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.codehaus.plexus.util.IOUtil;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.commons.Remapper;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PushbackInputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+
+/**
+ *  A shader capable of changing the specified classes for reflective access before relocating packages.
+ *  Custom version of {@link org.apache.maven.plugins.shade.DefaultShader}.
+ */
+@Component(role = Shader.class, hint = "ReflectiveAccessShader")
+public class ReflectiveAccessShader
+    extends AbstractLogEnabled
+    implements Shader {
+
+  private static final int BUFFER_SIZE = 32 * 1024;
+
+  public void shade(ShadeRequest shadeRequest)
+      throws IOException, MojoExecutionException {
+    Set<String> resources = new HashSet<>();
+
+    ManifestResourceTransformer manifestTransformer = null;
+    List<ResourceTransformer> transformers =
+        new ArrayList<>(shadeRequest.getResourceTransformers());
+    for (Iterator<ResourceTransformer> it = transformers.iterator(); it.hasNext();) {
+      ResourceTransformer transformer = it.next();
+      if (transformer instanceof ManifestResourceTransformer) {
+        manifestTransformer = (ManifestResourceTransformer) transformer;
+        it.remove();
+      }
+    }
+
+    RelocatorRemapper remapper = new RelocatorRemapper(shadeRequest.getRelocators());
+
+    // noinspection ResultOfMethodCallIgnored
+    shadeRequest.getUberJar().getParentFile().mkdirs();
+
+    JarOutputStream out = null;
+    try {
+      out = new JarOutputStream(new BufferedOutputStream(new FileOutputStream(shadeRequest.getUberJar())));
+      goThroughAllJarEntriesForManifestTransformer(shadeRequest, resources, manifestTransformer, out);
+
+      // CHECKSTYLE_OFF: MagicNumber
+      Multimap<String, File> duplicates = HashMultimap.create(10000, 3);
+      // CHECKSTYLE_ON: MagicNumber
+
+      shadeJars(shadeRequest, resources, transformers, remapper, out, duplicates);
+
+      // CHECKSTYLE_OFF: MagicNumber
+      Multimap<Collection<File>, String> overlapping = HashMultimap.create(20, 15);
+      // CHECKSTYLE_ON: MagicNumber
+
+      for (String clazz : duplicates.keySet()) {
+        Collection<File> jarz = duplicates.get(clazz);
+        if (jarz.size() > 1) {
+          overlapping.put(jarz, clazz);
+        }
+      }
+
+      // Log a summary of duplicates
+      logSummaryOfDuplicates(overlapping);
+
+      if (overlapping.keySet().size() > 0) {
+        showOverlappingWarning();
+      }
+
+      for (ResourceTransformer transformer : transformers) {
+        if (transformer.hasTransformedResource()) {
+          transformer.modifyOutputStream(out);
+        }
+      }
+
+      out.close();
+      out = null;
+    } finally {
+      IOUtil.close(out);
+    }
+
+    for (Filter filter : shadeRequest.getFilters()) {
+      filter.finished();
+    }
+  }
+
+  /**
+   * {@link InputStream} that can peek ahead at zip header bytes.
+   */
+  private static class ZipHeaderPeekInputStream extends PushbackInputStream {
+
+    private static final byte[] ZIP_HEADER = new byte[] {0x50, 0x4b, 0x03, 0x04};
+
+    private static final int HEADER_LEN = 4;
+
+    protected ZipHeaderPeekInputStream(InputStream in) {
+      super(in, HEADER_LEN);
+    }
+
+    public boolean hasZipHeader() throws IOException {
+      final byte[] header = new byte[HEADER_LEN];
+      super.read(header, 0, HEADER_LEN);
+      super.unread(header);
+      return Arrays.equals(header, ZIP_HEADER);
+    }
+  }
+
+  /**
+   * Data holder for CRC and Size.
+   */
+  private static class CrcAndSize {
+
+    private final CRC32 crc = new CRC32();
+
+    private long size;
+
+    CrcAndSize(InputStream inputStream) throws IOException {
+      load(inputStream);
+    }
+
+    private void load(InputStream inputStream) throws IOException {
+      byte[] buffer = new byte[BUFFER_SIZE];
+      int bytesRead;
+      while ((bytesRead = inputStream.read(buffer)) != -1) {
+        this.crc.update(buffer, 0, bytesRead);
+        this.size += bytesRead;
+      }
+    }
+
+    public void setupStoredEntry(JarEntry entry) {
+      entry.setSize(this.size);
+      entry.setCompressedSize(this.size);
+      entry.setCrc(this.crc.getValue());
+      entry.setMethod(ZipEntry.STORED);
+    }
+  }
+
+  private void shadeJars(ShadeRequest shadeRequest, Set<String> resources, List<ResourceTransformer> transformers,
+                         RelocatorRemapper remapper, JarOutputStream jos, Multimap<String, File> duplicates)
+      throws IOException, MojoExecutionException {
+    for (File jar : shadeRequest.getJars()) {
+
+      getLogger().debug("Processing JAR " + jar);
+
+      List<Filter> jarFilters = getFilters(jar, shadeRequest.getFilters());
+
+      try (JarFile jarFile = newJarFile(jar)) {
+
+        for (Enumeration<JarEntry> j = jarFile.entries(); j.hasMoreElements();) {
+          JarEntry entry = j.nextElement();
+
+          String name = entry.getName();
+
+          if (entry.isDirectory() || isFiltered(jarFilters, name)) {
+            continue;
+          }
+
+
+          if ("META-INF/INDEX.LIST".equals(name)) {
+            // we cannot allow the jar indexes to be copied over or the
+            // jar is useless. Ideally, we could create a new one
+            // later
+            continue;
+          }
+
+          if ("module-info.class".equals(name)) {
+            getLogger().warn("Discovered module-info.class. "
+                + "Shading will break its strong encapsulation.");
+            continue;
+          }
+
+          try {
+            shadeSingleJar(shadeRequest, resources, transformers, remapper, jos, duplicates, jar,
+                           jarFile, entry, name);
+          } catch (Exception e) {
+            throw new IOException(String.format("Problem shading JAR %s entry %s: %s", jar, name, e),
+                                  e);
+          }
+        }
+
+      }
+    }
+  }
+
+  private void shadeSingleJar(ShadeRequest shadeRequest, Set<String> resources,
+                              List<ResourceTransformer> transformers, RelocatorRemapper remapper,
+                              JarOutputStream jos, Multimap<String, File> duplicates, File jar, JarFile jarFile,
+                              JarEntry entry, String name)
+      throws IOException, MojoExecutionException {
+    try (InputStream in = jarFile.getInputStream(entry)) {
+      String mappedName = remapper.map(name);
+
+      int idx = mappedName.lastIndexOf('/');
+      if (idx != -1) {
+        // make sure dirs are created
+        String dir = mappedName.substring(0, idx);
+        if (!resources.contains(dir)) {
+          addDirectory(resources, jos, dir, entry.getTime());
+        }
+      }
+
+      duplicates.put(name, jar);
+      if (name.endsWith(".class")) {
+        addRemappedClass(remapper, jos, jar, name, entry.getTime(), in, transformers);
+      } else if (shadeRequest.isShadeSourcesContent() && name.endsWith(".java")) {
+        // Avoid duplicates
+        if (resources.contains(mappedName)) {
+          return;
+        }
+
+        addJavaSource(resources, jos, mappedName, entry.getTime(), in, shadeRequest.getRelocators());
+      } else {
+        if (!resourceTransformed(transformers, mappedName, in, shadeRequest.getRelocators(),
+                                 entry.getTime())) {
+          // Avoid duplicates that aren't accounted for by the resource transformers
+          if (resources.contains(mappedName)) {
+            getLogger().debug("We have a duplicate " + name + " in " + jar);
+            return;
+          }
+
+          addResource(resources, jos, mappedName, entry, jarFile);
+        } else {
+          duplicates.remove(name, jar);
+        }
+      }
+    }
+  }
+
+  private void goThroughAllJarEntriesForManifestTransformer(ShadeRequest shadeRequest, Set<String> resources,
+                                                            ManifestResourceTransformer manifestTransformer,
+                                                            JarOutputStream jos)
+      throws IOException {
+    if (manifestTransformer != null) {
+      for (File jar : shadeRequest.getJars()) {
+        try (JarFile jarFile = newJarFile(jar)) {
+          for (Enumeration<JarEntry> en = jarFile.entries(); en.hasMoreElements();) {
+            JarEntry entry = en.nextElement();
+            String resource = entry.getName();
+            if (manifestTransformer.canTransformResource(resource)) {
+              resources.add(resource);
+              try (InputStream inputStream = jarFile.getInputStream(entry)) {
+                manifestTransformer.processResource(resource, inputStream,
+                                                    shadeRequest.getRelocators(), entry.getTime());
+              }
+              break;
+            }
+          }
+        }
+      }
+      if (manifestTransformer.hasTransformedResource()) {
+        manifestTransformer.modifyOutputStream(jos);
+      }
+    }
+  }
+
+  private void showOverlappingWarning() {
+    getLogger().warn("maven-shade-plugin has detected that some class files are");
+    getLogger().warn("present in two or more JARs. When this happens, only one");
+    getLogger().warn("single version of the class is copied to the uber jar.");
+    getLogger().warn("Usually this is not harmful and you can skip these warnings,");
+    getLogger().warn("otherwise try to manually exclude artifacts based on");
+    getLogger().warn("mvn dependency:tree -Ddetail=true and the above output.");
+    getLogger().warn("See http://maven.apache.org/plugins/maven-shade-plugin/");
+  }
+
+  private void logSummaryOfDuplicates(Multimap<Collection<File>, String> overlapping) {
+    for (Collection<File> jarz : overlapping.keySet()) {
+      List<String> jarzS = new ArrayList<>();
+
+      for (File jjar : jarz) {
+        jarzS.add(jjar.getName());
+      }
+
+      Collections.sort(jarzS); // deterministic messages to be able to compare outputs (useful on CI)
+
+      List<String> classes = new LinkedList<>();
+      List<String> resources = new LinkedList<>();
+
+      for (String name : overlapping.get(jarz)) {
+        if (name.endsWith(".class")) {
+          classes.add(name.replace(".class", "").replace("/", "."));
+        } else {
+          resources.add(name);
+        }
+      }
+
+      //CHECKSTYLE_OFF: LineLength
+      final Collection<String> overlaps = new ArrayList<>();
+      if (!classes.isEmpty()) {
+        if (resources.size() == 1) {
+          overlaps.add("class");
+        } else {
+          overlaps.add("classes");
+        }
+      }
+      if (!resources.isEmpty()) {
+        if (resources.size() == 1) {
+          overlaps.add("resource");
+        } else {
+          overlaps.add("resources");
+        }
+      }
+
+      final List<String> all = new ArrayList<>(classes.size() + resources.size());
+      all.addAll(classes);
+      all.addAll(resources);
+
+      getLogger().warn(
+                       StringUtils.join(jarzS, ", ") + " define " + all.size()
+                           + " overlapping " + StringUtils.join(overlaps, " and ") + ": ");
+      //CHECKSTYLE_ON: LineLength
+
+      Collections.sort(all);
+
+      int max = 10;
+
+      for (int i = 0; i < Math.min(max, all.size()); i++) {
+        getLogger().warn("  - " + all.get(i));
+      }
+
+      if (all.size() > max) {
+        getLogger().warn("  - " + (all.size() - max) + " more...");
+      }
+
+    }
+  }
+
+  private JarFile newJarFile(File jar)
+      throws IOException {
+    try {
+      return new JarFile(jar);
+    } catch (ZipException zex) {
+      // JarFile is not very verbose and doesn't tell the user which file it was
+      // so we will create a new Exception instead
+      throw new ZipException("error in opening zip file " + jar);
+    }
+  }
+
+  private List<Filter> getFilters(File jar, List<Filter> filters) {
+    List<Filter> list = new ArrayList<>();
+
+    for (Filter filter : filters) {
+      if (filter.canFilter(jar)) {
+        list.add(filter);
+      }
+
+    }
+
+    return list;
+  }
+
+  private void addDirectory(Set<String> resources, JarOutputStream jos, String name, long time)
+      throws IOException {
+    if (name.lastIndexOf('/') > 0) {
+      String parent = name.substring(0, name.lastIndexOf('/'));
+      if (!resources.contains(parent)) {
+        addDirectory(resources, jos, parent, time);
+      }
+    }
+
+    // directory entries must end in "/"
+    JarEntry entry = new JarEntry(name + "/");
+    entry.setTime(time);
+    jos.putNextEntry(entry);
+
+    resources.add(name);
+  }
+
+  private void addRemappedClass(RelocatorRemapper remapper, JarOutputStream jos, File jar, String name,
+                                long time, InputStream is, List<ResourceTransformer> transformers)
+      throws IOException, MojoExecutionException {
+    if (!remapper.hasRelocators()) {
+      try {
+        JarEntry entry = new JarEntry(name);
+        entry.setTime(time);
+        jos.putNextEntry(entry);
+        IOUtil.copy(is, jos);
+      } catch (ZipException e) {
+        getLogger().debug("We have a duplicate " + name + " in " + jar);
+      }
+
+      return;
+    }
+
+    ClassReader cr = new ClassReader(is);
+
+    // We don't pass the ClassReader here. This forces the ClassWriter to rebuild the constant pool.
+    // Copying the original constant pool should be avoided because it would keep references
+    // to the original class names. This is not a problem at runtime (because these entries in the
+    // constant pool are never used), but confuses some tools such as Felix' maven-bundle-plugin
+    // that use the constant pool to determine the dependencies of a class.
+    ClassWriter cw = new ClassWriter(0);
+
+    final String pkg = name.substring(0, name.lastIndexOf('/') + 1);
+    ClassVisitor cv = new ReflectiveAccessClassRemapper(cw, remapper, transformers) {
+
+      @Override
+      public void visitSource(final String source, final String debug) {
+        if (source == null) {
+          super.visitSource(source, debug);
+        } else {
+          final String fqSource = pkg + source;
+          final String mappedSource = remapper.map(fqSource);
+          final String filename = mappedSource.substring(mappedSource.lastIndexOf('/') + 1);
+          super.visitSource(filename, debug);
+        }
+      }
+    };
+
+    try {
+      cr.accept(cv, ClassReader.EXPAND_FRAMES);
+    } catch (Throwable ise) {
+      throw new MojoExecutionException("Error in ASM processing class " + name, ise);
+    }
+
+    byte[] renamedClass = cw.toByteArray();
+
+    // Need to take the .class off for remapping evaluation
+    String mappedName = remapper.map(name.substring(0, name.indexOf('.')));
+
+    try {
+      // Now we put it back on so the class file is written out with the right extension.
+      JarEntry entry = new JarEntry(mappedName + ".class");
+      entry.setTime(time);
+      jos.putNextEntry(entry);
+
+      jos.write(renamedClass);
+    } catch (ZipException e) {
+      getLogger().debug("We have a duplicate " + mappedName + " in " + jar);
+    }
+  }
+
+  private boolean isFiltered(List<Filter> filters, String name) {
+    for (Filter filter : filters) {
+      if (filter.isFiltered(name)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private boolean resourceTransformed(List<ResourceTransformer> resourceTransformers, String name, InputStream is,
+                                      List<Relocator> relocators, long time)
+      throws IOException {
+    boolean resourceTransformed = false;
+
+    for (ResourceTransformer transformer : resourceTransformers) {
+      if (transformer.canTransformResource(name)) {
+        getLogger().debug("Transforming " + name + " using " + transformer.getClass().getName());
+
+        if (transformer instanceof ReproducibleResourceTransformer) {
+          ((ReproducibleResourceTransformer) transformer).processResource(name, is, relocators, time);
+        } else {
+          transformer.processResource(name, is, relocators);
+        }
+
+        resourceTransformed = true;
+
+        break;
+      }
+    }
+    return resourceTransformed;
+  }
+
+  private void addJavaSource(Set<String> resources, JarOutputStream jos, String name, long time, InputStream is,
+                             List<Relocator> relocators)
+      throws IOException {
+    JarEntry entry = new JarEntry(name);
+    entry.setTime(time);
+    jos.putNextEntry(entry);
+
+    String sourceContent = IOUtil.toString(new InputStreamReader(is, StandardCharsets.UTF_8));
+
+    for (Relocator relocator : relocators) {
+      sourceContent = relocator.applyToSourceContent(sourceContent);
+    }
+
+    final Writer writer = new OutputStreamWriter(jos, StandardCharsets.UTF_8);
+    writer.write(sourceContent);
+    writer.flush();
+
+    resources.add(name);
+  }
+
+  private void addResource(Set<String> resources, JarOutputStream jos, String name, JarEntry originalEntry,
+                           JarFile jarFile)
+      throws IOException {
+    ZipHeaderPeekInputStream inputStream = new ZipHeaderPeekInputStream(jarFile.getInputStream(originalEntry));
+    try {
+      final JarEntry entry = new JarEntry(name);
+
+      // We should not change compressed level of uncompressed entries, otherwise JVM can't load these nested jars
+      if (inputStream.hasZipHeader() && originalEntry.getMethod() == ZipEntry.STORED) {
+        new CrcAndSize(inputStream).setupStoredEntry(entry);
+        inputStream.close();
+        inputStream = new ZipHeaderPeekInputStream(jarFile.getInputStream(originalEntry));
+      }
+
+
+      entry.setTime(originalEntry.getTime());
+
+      jos.putNextEntry(entry);
+
+      IOUtil.copy(inputStream, jos);
+
+      resources.add(name);
+    } finally {
+      inputStream.close();
+    }
+  }
+
+  static class RelocatorRemapper
+      extends Remapper {
+
+    private final Pattern classPattern = Pattern.compile("(\\[*)?L(.+);");
+
+    List<Relocator> relocators;
+
+    RelocatorRemapper(List<Relocator> relocators) {
+      this.relocators = relocators;
+    }
+
+    public boolean hasRelocators() {
+      return !relocators.isEmpty();
+    }
+
+    public Object mapValue(Object object) {
+      if (object instanceof String) {
+        String name = (String) object;
+        String value = name;
+
+        String prefix = "";
+        String suffix = "";
+
+        Matcher m = classPattern.matcher(name);
+        if (m.matches()) {
+          prefix = m.group(1) + "L";
+          suffix = ";";
+          name = m.group(2);
+        }
+
+        for (Relocator r : relocators) {
+          if (r.canRelocateClass(name)) {
+            value = prefix + r.relocateClass(name) + suffix;
+            break;
+          } else if (r.canRelocatePath(name)) {
+            value = prefix + r.relocatePath(name) + suffix;
+            break;
+          }
+        }
+
+        return value;
+      }
+
+      return super.mapValue(object);
+    }
+
+    public String map(String name) {
+      String value = name;
+
+      String prefix = "";
+      String suffix = "";
+
+      Matcher m = classPattern.matcher(name);
+      if (m.matches()) {
+        prefix = m.group(1) + "L";
+        suffix = ";";
+        name = m.group(2);
+      }
+
+      for (Relocator r : relocators) {
+        if (r.canRelocatePath(name)) {
+          value = prefix + r.relocatePath(name) + suffix;
+          break;
+        }
+      }
+
+      return value;
+    }
+
+  }
+
+}

--- a/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessShaderTransformer.java
+++ b/mule-shaders-module/src/main/java/org/mule/module/shaders/api/ReflectiveAccessShaderTransformer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mule.module.shaders.api;
+
+import org.apache.maven.plugins.shade.relocation.Relocator;
+import org.apache.maven.plugins.shade.resource.ResourceTransformer;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.jar.JarOutputStream;
+
+/**
+ * The transformer configuration needed by the shader to enable reflective access for the specified class members.
+ */
+public class ReflectiveAccessShaderTransformer implements ResourceTransformer {
+
+  private List<ClassMember> members;
+
+  @Override
+  public boolean canTransformResource(String resource) {
+    return false;
+  }
+
+  @Override
+  public boolean hasTransformedResource() {
+    return false;
+  }
+
+  @Override
+  public void processResource(String resource, InputStream is, List<Relocator> relocators) {}
+
+  @Override
+  public void modifyOutputStream(JarOutputStream os) {}
+
+  public List<ClassMember> getMembers() {
+    return members;
+  }
+
+  public void setMembers(List<ClassMember> members) {
+    this.members = members;
+  }
+
+  public static class ClassMember {
+
+    private String className;
+    private String memberName;
+
+    public boolean equals(String className, String memberName) {
+      return Objects.equals(this.className, className) && Objects.equals(this.memberName, memberName);
+    }
+
+    public String getClassName() {
+      return className;
+    }
+
+    public void setClassName(String className) {
+      this.className = className;
+    }
+
+    public String getMemberName() {
+      return memberName;
+    }
+
+    public void setMemberName(String memberName) {
+      this.memberName = memberName;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <org.mozilla.rhino.version>1.7.14</org.mozilla.rhino.version>
         <com.networknt.version>1.0.76</com.networknt.version>
         <settings.file>${java.io.tmpdir}/effective-settings.xml</settings.file>
-        <munit.version>2.3.4</munit.version>
-        <mtf.tools.version>1.1.2</mtf.tools.version>
+        <munit.version>3.1.0-SNAPSHOT</munit.version>
+        <mtf.tools.version>1.2.0-SNAPSHOT</mtf.tools.version>
         <file.connector.version>1.5.1</file.connector.version>
         <mtf.javaopts></mtf.javaopts>
         <jacoco.version>0.8.10</jacoco.version>
@@ -36,6 +36,9 @@
         <license.maven.plugin.version>4.2</license.maven.plugin.version>
         <licensePath>LICENSE_HEADER_CPAL.txt</licensePath>
         <licenseYear>2023</licenseYear>
+
+        <!-- runtime version to run -->
+        <runtimeVersion>4.6.0-SNAPSHOT</runtimeVersion>
     </properties>
 
     <dependencies>
@@ -200,7 +203,7 @@
             <plugin>
                 <groupId>com.mulesoft.munit</groupId>
                 <artifactId>munit-extensions-maven-plugin</artifactId>
-                <version>${munit.extensions.maven.plugin.version}</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-json-module</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
     <packaging>mule-extension</packaging>
     <name>Json Module</name>
 
     <properties>
+        <mule.sdk.api.version>0.7.0</mule.sdk.api.version>
+        <mule.extensions.shade.plugin.version>1.0.4</mule.extensions.shade.plugin.version>
+        <exec.maven.plugin.version>1.6.0</exec.maven.plugin.version>
         <jackson.version>2.15.2</jackson.version>
         <jackson.databind.version>2.15.2</jackson.databind.version>
         <json.schema.validation.version>2.2.14</json.schema.validation.version>
@@ -27,21 +30,27 @@
         <org.mozilla.rhino.version>1.7.14</org.mozilla.rhino.version>
         <com.networknt.version>1.0.76</com.networknt.version>
         <settings.file>${java.io.tmpdir}/effective-settings.xml</settings.file>
-        <munit.version>3.1.0-SNAPSHOT</munit.version>
-        <mtf.tools.version>1.2.0-SNAPSHOT</mtf.tools.version>
-        <file.connector.version>1.5.1</file.connector.version>
+        <munit.version>3.1.0</munit.version>
+        <mtf.tools.version>1.2.0</mtf.tools.version>
+        <munit.extensions.maven.plugin.version>1.2.0</munit.extensions.maven.plugin.version>
+        <file.connector.version>1.5.2</file.connector.version>
         <mtf.javaopts></mtf.javaopts>
         <jacoco.version>0.8.10</jacoco.version>
         <mulesoftLicenseVersion>1.4.0</mulesoftLicenseVersion>
         <license.maven.plugin.version>4.2</license.maven.plugin.version>
-        <licensePath>LICENSE_HEADER_CPAL.txt</licensePath>
-        <licenseYear>2023</licenseYear>
-
-        <!-- runtime version to run -->
-        <runtimeVersion>4.6.0-SNAPSHOT</runtimeVersion>
+        <licensePath>LICENSE_HEADER.txt</licensePath>
+        <licenseYear>2024</licenseYear>
+        <!-- munit-tools 3.1.0 requires runtime 4.3.0 or higher -->
+        <runtimeVersion>4.3.0</runtimeVersion>
+        <maven.repo.local>${settings.localRepository}</maven.repo.local>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.mule.sdk</groupId>
+            <artifactId>mule-sdk-api</artifactId>
+            <version>${mule.sdk.api.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -126,6 +135,94 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>build-mule-shaders-module</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>mule-shaders-module</workingDirectory>
+                            <executable>mvn</executable>
+                            <arguments>
+                                <argument>install</argument>
+                                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.mule.runtime.plugins</groupId>
+                <artifactId>mule-extensions-shade-plugin</artifactId>
+                <version>${mule.extensions.shade.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mule.modules</groupId>
+                        <artifactId>mule-shaders-module</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.github.java-json-tools</groupId>
+                        <artifactId>json-schema-validator</artifactId>
+                        <version>${json.schema.validation.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <shaderHint>ReflectiveAccessShader</shaderHint>
+                    <artifactSet>
+                        <includes>
+                            <include>com.github.java-json-tools:*</include>
+                        </includes>
+                    </artifactSet>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.github.fge</pattern>
+                            <shadedPattern>org.mule.module.json.internal.shaded.com.github.fge</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <transformers>
+                        <transformer implementation="org.mule.module.shaders.api.ReflectiveAccessShaderTransformer">
+                            <members>
+                                <classMember>
+                                    <className>com.github.fge.jackson.JsonNodeReader</className>
+                                    <memberName>BUNDLE</memberName>
+                                </classMember>
+                                <classMember>
+                                    <className>com.github.fge.jsonschema.core.report.ProcessingMessage</className>
+                                    <memberName>BUNDLE</memberName>
+                                </classMember>
+                                <classMember>
+                                    <className>com.github.fge.msgsimple.load.MessageBundles</className>
+                                    <memberName>BUNDLES</memberName>
+                                </classMember>
+                                <classMember>
+                                    <className>com.github.fge.msgsimple.bundle.MessageBundle</className>
+                                    <memberName>providers</memberName>
+                                </classMember>
+                                <classMember>
+                                    <className>com.github.fge.msgsimple.provider.LoadingMessageSourceProvider</className>
+                                    <memberName>service</memberName>
+                                </classMember>
+                            </members>
+                        </transformer>
+                    </transformers>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>${license.maven.plugin.version}</version>
@@ -203,7 +300,7 @@
             <plugin>
                 <groupId>com.mulesoft.munit</groupId>
                 <artifactId>munit-extensions-maven-plugin</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>${munit.extensions.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>test</id>
@@ -226,6 +323,11 @@
 
                 </configuration>
                 <dependencies>
+                    <dependency>
+                        <groupId>com.github.java-json-tools</groupId>
+                        <artifactId>json-schema-validator</artifactId>
+                        <version>${json.schema.validation.version}</version>
+                    </dependency>
                     <dependency>
                         <groupId>com.mulesoft.munit</groupId>
                         <artifactId>munit-runner</artifactId>
@@ -254,4 +356,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>mule-plugin</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>mule-plugin</id>
+            <name>Mule Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-json-module</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.0-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>Json Module</name>
 
@@ -27,7 +27,6 @@
         <jakarta.mail.version>2.0.1</jakarta.mail.version>
         <commons.pool2.version>2.11.1</commons.pool2.version>
         <commons.lang3.version>3.13.0</commons.lang3.version>
-        <org.mozilla.rhino.version>1.7.14</org.mozilla.rhino.version>
         <com.networknt.version>1.0.76</com.networknt.version>
         <settings.file>${java.io.tmpdir}/effective-settings.xml</settings.file>
         <munit.version>3.1.0</munit.version>

--- a/src/it/tita/pom.xml
+++ b/src/it/tita/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-json-module</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
     <packaging>jar</packaging>
     <name>Json Module - Integration Tests</name>
 

--- a/src/it/tita/pom.xml
+++ b/src/it/tita/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-json-module</artifactId>
-    <version>2.5.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Json Module - Integration Tests</name>
 

--- a/src/it/tita/src/test/java/com/mulesoft/json/it/RedeploymentTestCase.java
+++ b/src/it/tita/src/test/java/com/mulesoft/json/it/RedeploymentTestCase.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.mulesoft.json.it;
 
@@ -30,8 +40,9 @@ public class RedeploymentTestCase{
     private static final Identifier api2 = identifier("api2");
     private static final Identifier port = identifier("port");
     private static final Identifier REDEPLOYABLE_APP = identifier("json-module-app");
-    
-    @Standalone(testing="4.3.0")
+    private static final String RUNNER_COMPATIBLE_RUNTIME_VERSION = "4.3.0-HF-SNAPSHOT";
+
+    @Standalone(testing = RUNNER_COMPATIBLE_RUNTIME_VERSION)
     private Runtime runtime;
 
     @Application

--- a/src/it/tita/src/test/resources/json-module-app-pom.xml
+++ b/src/it/tita/src/test/resources/json-module-app-pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <app.runtime>4.3.0</app.runtime>
         <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>
-        <json.module.version>2.5.0</json.module.version>
+        <mule.json.module.version>2.5.0-SNAPSHOT</mule.json.module.version>
     </properties>
 
     <build>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-json-module</artifactId>
-            <version>2.5.0</version>
+            <version>${mule.json.module.version}</version>
             <classifier>mule-plugin</classifier>
         </dependency>
     </dependencies>

--- a/src/it/tita/src/test/resources/json-module-app-pom.xml
+++ b/src/it/tita/src/test/resources/json-module-app-pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <app.runtime>4.3.0</app.runtime>
         <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>
-        <json.module.version>2.5.0-SNAPSHOT</json.module.version>
+        <json.module.version>2.5.0</json.module.version>
     </properties>
 
     <build>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-json-module</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>2.5.0</version>
             <classifier>mule-plugin</classifier>
         </dependency>
     </dependencies>

--- a/src/main/java/org/mule/module/json/api/JsonError.java
+++ b/src/main/java/org/mule/module/json/api/JsonError.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.api;
 

--- a/src/main/java/org/mule/module/json/api/JsonSchemaDereferencingMode.java
+++ b/src/main/java/org/mule/module/json/api/JsonSchemaDereferencingMode.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.api;
 

--- a/src/main/java/org/mule/module/json/api/SchemaRedirect.java
+++ b/src/main/java/org/mule/module/json/api/SchemaRedirect.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.api;
 

--- a/src/main/java/org/mule/module/json/api/SchemaRedirect.java
+++ b/src/main/java/org/mule/module/json/api/SchemaRedirect.java
@@ -6,6 +6,7 @@
  */
 package org.mule.module.json.api;
 
+import org.mule.module.json.internal.util.ExcludeFromGeneratedCoverage;
 import org.mule.runtime.extension.api.annotation.param.Parameter;
 
 /**
@@ -33,5 +34,15 @@ public class SchemaRedirect {
 
   public String getTo() {
     return to;
+  }
+
+  @ExcludeFromGeneratedCoverage
+  public void setFrom(String from) {
+    this.from = from;
+  }
+
+  @ExcludeFromGeneratedCoverage
+  public void setTo(String to) {
+    this.to = to;
   }
 }

--- a/src/main/java/org/mule/module/json/internal/JsonAnyStaticTypeResolver.java
+++ b/src/main/java/org/mule/module/json/internal/JsonAnyStaticTypeResolver.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonModule.java
+++ b/src/main/java/org/mule/module/json/internal/JsonModule.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 
@@ -12,6 +22,11 @@ import org.mule.runtime.extension.api.annotation.Operations;
 import org.mule.runtime.extension.api.annotation.dsl.xml.Xml;
 import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
 
+import org.mule.sdk.api.annotation.JavaVersionSupport;
+
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_11;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_17;
+import static org.mule.sdk.api.meta.JavaVersion.JAVA_8;
 
 /**
  * The JSON module contains tools to help you deal with JSON documents
@@ -20,6 +35,7 @@ import org.mule.runtime.extension.api.annotation.error.ErrorTypes;
 @Extension(name = "JSON")
 @ErrorTypes(JsonError.class)
 @Operations(ValidateJsonSchemaOperation.class)
+@JavaVersionSupport({JAVA_8, JAVA_11, JAVA_17})
 public class JsonModule {
 
 }

--- a/src/main/java/org/mule/module/json/internal/JsonSchema.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchema.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonSchemaParser.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchemaParser.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonSchemaValidationFactory.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchemaValidationFactory.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonSchemaValidator.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchemaValidator.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonSchemaValidatorJavaJsonToolsWrapper.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchemaValidatorJavaJsonToolsWrapper.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/JsonSchemaValidatorNetworkntWrapper.java
+++ b/src/main/java/org/mule/module/json/internal/JsonSchemaValidatorNetworkntWrapper.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/LibraryLink.java
+++ b/src/main/java/org/mule/module/json/internal/LibraryLink.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/NetworkNTLink.java
+++ b/src/main/java/org/mule/module/json/internal/NetworkNTLink.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/ValidateJsonSchemaOperation.java
+++ b/src/main/java/org/mule/module/json/internal/ValidateJsonSchemaOperation.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/ValidatorCommonUtils.java
+++ b/src/main/java/org/mule/module/json/internal/ValidatorCommonUtils.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/ValidatorKey.java
+++ b/src/main/java/org/mule/module/json/internal/ValidatorKey.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal;
 

--- a/src/main/java/org/mule/module/json/internal/cleanup/InstanceMonitor.java
+++ b/src/main/java/org/mule/module/json/internal/cleanup/InstanceMonitor.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal.cleanup;
 

--- a/src/main/java/org/mule/module/json/internal/cleanup/JsonModuleResourceReleaser.java
+++ b/src/main/java/org/mule/module/json/internal/cleanup/JsonModuleResourceReleaser.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal.cleanup;
 
@@ -54,28 +64,18 @@ public class JsonModuleResourceReleaser {
   public synchronized void releaseExecutors() {
     LOGGER.debug("Stopping the known executors services");
     Field bundleField = null;
-    boolean isAccessible = false;
     try {
       bundleField = JsonNodeReader.class.getDeclaredField("BUNDLE");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       MessageBundle messageBundle = (MessageBundle) bundleField.get(null);
       cleanMessageBundle(messageBundle);
     } catch (NoSuchFieldException | IllegalAccessException | InterruptedException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service reference of the JsonNodeReader class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
     bundleField = null;
-    isAccessible = false;
     try {
       bundleField = MessageBundles.class.getDeclaredField("BUNDLES");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       Map<Class<? extends MessageBundleLoader>, MessageBundle> bundles =
           (Map<Class<? extends MessageBundleLoader>, MessageBundle>) bundleField.get(null);
       for (MessageBundle bundle : bundles.values()) {
@@ -84,28 +84,17 @@ public class JsonModuleResourceReleaser {
     } catch (NoSuchFieldException | IllegalAccessException | InterruptedException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service references of the MessageBundles class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
     bundleField = null;
-    isAccessible = false;
 
     try {
       bundleField = ProcessingMessage.class.getDeclaredField("BUNDLE");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       MessageBundle messageBundle = (MessageBundle) bundleField.get(null);
       cleanMessageBundle(messageBundle);
     } catch (NoSuchFieldException | IllegalAccessException | InterruptedException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service references of the ProcessingMessage class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
   }
@@ -121,36 +110,20 @@ public class JsonModuleResourceReleaser {
 
     Field providersField = null;
     Field serviceField = null;
-    boolean isProviderFieldAccessible = false;
-    boolean isServiceFieldAccessible = false;
 
-    try {
-      providersField = MessageBundle.class.getDeclaredField("providers");
-      isProviderFieldAccessible = providersField.isAccessible();
-      providersField.setAccessible(true);
+    providersField = MessageBundle.class.getDeclaredField("providers");
 
-      List<MessageSourceProvider> messageSourceProviders = (List<MessageSourceProvider>) providersField.get(bundle);
-      for (MessageSourceProvider provider : messageSourceProviders) {
-        if (provider instanceof LoadingMessageSourceProvider) {
-          try {
-            serviceField = LoadingMessageSourceProvider.class.getDeclaredField("service");
-            isServiceFieldAccessible = serviceField.isAccessible();
-            serviceField.setAccessible(true);
-            ExecutorService service = (ExecutorService) serviceField.get(provider);
-            service.shutdown();
-            service.awaitTermination(10, SECONDS);
-          } finally {
-            if (serviceField != null) {
-              serviceField.setAccessible(isServiceFieldAccessible);
-            }
-            serviceField = null;
-            isServiceFieldAccessible = false;
-          }
+    List<MessageSourceProvider> messageSourceProviders = (List<MessageSourceProvider>) providersField.get(bundle);
+    for (MessageSourceProvider provider : messageSourceProviders) {
+      if (provider instanceof LoadingMessageSourceProvider) {
+        try {
+          serviceField = LoadingMessageSourceProvider.class.getDeclaredField("service");
+          ExecutorService service = (ExecutorService) serviceField.get(provider);
+          service.shutdown();
+          service.awaitTermination(10, SECONDS);
+        } finally {
+          serviceField = null;
         }
-      }
-    } finally {
-      if (providersField != null) {
-        providersField.setAccessible(isProviderFieldAccessible);
       }
     }
   }
@@ -160,29 +133,19 @@ public class JsonModuleResourceReleaser {
    */
   public synchronized void restoreExecutorServices() {
     Field bundleField = null;
-    boolean isAccessible = false;
     try {
       bundleField = JsonNodeReader.class.getDeclaredField("BUNDLE");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       MessageBundle messageBundle = (MessageBundle) bundleField.get(null);
       restoreMessageBundle(messageBundle);
     } catch (NoSuchFieldException | IllegalAccessException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service reference of the JsonNodeReader class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
     bundleField = null;
-    isAccessible = false;
 
     try {
       bundleField = MessageBundles.class.getDeclaredField("BUNDLES");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       Map<Class<? extends MessageBundleLoader>, MessageBundle> bundles =
           (Map<Class<? extends MessageBundleLoader>, MessageBundle>) bundleField.get(null);
       for (MessageBundle bundle : bundles.values()) {
@@ -191,28 +154,17 @@ public class JsonModuleResourceReleaser {
     } catch (NoSuchFieldException | IllegalAccessException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service references of the MessageBundles class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
     bundleField = null;
-    isAccessible = false;
 
     try {
       bundleField = ProcessingMessage.class.getDeclaredField("BUNDLE");
-      isAccessible = bundleField.isAccessible();
-      bundleField.setAccessible(true);
       MessageBundle messageBundle = (MessageBundle) bundleField.get(null);
       restoreMessageBundle(messageBundle);
     } catch (NoSuchFieldException | IllegalAccessException ex) {
       LOGGER.error("Caught exception while stopping the Executor Service references of the ProcessingMessage class: {}",
                    ex.getMessage(), ex);
-    } finally {
-      if (bundleField != null) {
-        bundleField.setAccessible(isAccessible);
-      }
     }
 
   }
@@ -228,45 +180,26 @@ public class JsonModuleResourceReleaser {
       throws NoSuchFieldException, IllegalAccessException {
 
     Field providersField = null;
-    boolean isProvidersFieldAccessible = false;
     Field serviceField = null;
-    boolean isServiceFieldAccessible = false;
 
+    providersField = MessageBundle.class.getDeclaredField("providers");
 
-    try {
-      providersField = MessageBundle.class.getDeclaredField("providers");
-      isProvidersFieldAccessible = providersField.isAccessible();
-      providersField.setAccessible(true);
+    List<MessageSourceProvider> messageSourceProviders = (List<MessageSourceProvider>) providersField.get(bundle);
 
-      List<MessageSourceProvider> messageSourceProviders = (List<MessageSourceProvider>) providersField.get(bundle);
-
-      for (MessageSourceProvider provider : messageSourceProviders) {
-        if (provider instanceof LoadingMessageSourceProvider) {
-          try {
-            serviceField = LoadingMessageSourceProvider.class.getDeclaredField("service");
-            isServiceFieldAccessible = serviceField.isAccessible();
-            serviceField.setAccessible(true);
-            ExecutorService service = (ExecutorService) serviceField.get(provider);
-            if (service.isShutdown()) {
-              service = schedulerService.customScheduler(SchedulerConfig.config().withMaxConcurrentTasks(3).withPrefix("pool"));
-              serviceField.set(provider, service);
-            }
-          } finally {
-            if (serviceField != null) {
-              serviceField.setAccessible(isServiceFieldAccessible);
-              serviceField = null;
-            }
-            isServiceFieldAccessible = false;
+    for (MessageSourceProvider provider : messageSourceProviders) {
+      if (provider instanceof LoadingMessageSourceProvider) {
+        try {
+          serviceField = LoadingMessageSourceProvider.class.getDeclaredField("service");
+          ExecutorService service = (ExecutorService) serviceField.get(provider);
+          if (service.isShutdown()) {
+            service = schedulerService.customScheduler(SchedulerConfig.config().withMaxConcurrentTasks(3).withPrefix("pool"));
+            serviceField.set(provider, service);
           }
+        } finally {
+          serviceField = null;
         }
       }
-
-    } finally {
-      if (providersField != null) {
-        providersField.setAccessible(isProvidersFieldAccessible);
-      }
     }
-
 
   }
 

--- a/src/main/java/org/mule/module/json/internal/error/SchemaValidationException.java
+++ b/src/main/java/org/mule/module/json/internal/error/SchemaValidationException.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal.error;
 

--- a/src/main/java/org/mule/module/json/internal/error/SchemaValidatorErrorTypeProvider.java
+++ b/src/main/java/org/mule/module/json/internal/error/SchemaValidatorErrorTypeProvider.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal.error;
 

--- a/src/main/java/org/mule/module/json/internal/util/ExcludeFromGeneratedCoverage.java
+++ b/src/main/java/org/mule/module/json/internal/util/ExcludeFromGeneratedCoverage.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Salesforce, Inc. All rights reserved.
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.json.internal.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface ExcludeFromGeneratedCoverage {
+
+}

--- a/src/main/java/org/mule/module/json/internal/util/ExcludeFromGeneratedCoverage.java
+++ b/src/main/java/org/mule/module/json/internal/util/ExcludeFromGeneratedCoverage.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mule.module.json.internal.util;
 

--- a/src/test/java/ClassUtils.java
+++ b/src/test/java/ClassUtils.java
@@ -14,21 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.mule.module.json.internal;
+import org.mule.runtime.module.artifact.api.classloader.ClassLoaderRepository;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.reflect.Field;
 
 /**
- * Link of the chain, determinate when {@link JsonSchemaValidatorJavaJsonToolsWrapper} have to be returned
+ * Provides utilities related to {@link Class} instances needed for tests due to DataWeave limitations.
  */
-public class JavaJsonToolsLink extends LibraryLink {
+public class ClassUtils {
 
-  public JavaJsonToolsLink(LibraryLink nextLink) {
-    super(nextLink);
+  private ClassUtils() {}
+
+  public static Field getDeclaredField(ClassLoader classLoader, String className, String fieldName)
+      throws ClassNotFoundException, NoSuchFieldException {
+    return classLoader.loadClass(className).getDeclaredField(fieldName);
   }
 
-  @Override
-  public JsonSchemaValidator getWrapper(ValidatorKey key, JsonNode schemaJsonNode) {
-    return new JsonSchemaValidatorJavaJsonToolsWrapper(key, schemaJsonNode);
+  public static ClassLoader getClassLoader(ClassLoaderRepository repository, String classLoaderId) {
+    return repository.find(classLoaderId).orElse(null);
   }
 }

--- a/src/test/java/SystemPropertyUtils.java
+++ b/src/test/java/SystemPropertyUtils.java
@@ -1,8 +1,18 @@
 /*
- * Copyright 2023 Salesforce, Inc. All rights reserved.
- * The software in this package is published under the terms of the CPAL v1.0
- * license, a copy of which has been included with this distribution in the
- * LICENSE.txt file.
+ * Copyright (c) 2024, Salesforce, Inc.
+ * SPDX-License-Identifier: Apache-2
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 import java.util.Properties;
 

--- a/src/test/munit/JsonToolsReflectiveAccessTestCase.xml
+++ b/src/test/munit/JsonToolsReflectiveAccessTestCase.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+        xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+        xmlns="http://www.mulesoft.org/schema/mule/core"
+        xsi:schemaLocation="
+        http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+        http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+        http://www.mulesoft.org/schema/mule/munit-tools http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        ">
+    <global-property name="extensionName" value="JSON"/>
+    <global-property name="shadePackage" value="org.mule.module.json.internal.shaded"/>
+    <munit:config name="JsonToolsReflectiveAccessTestCase.xml">
+        <munit:parameterizations>
+            <munit:parameterization name="JsonNodeReader">
+                <munit:parameters>
+                    <munit:parameter propertyName="className" value="com.github.fge.jackson.JsonNodeReader"/>
+                    <munit:parameter propertyName="memberName" value="BUNDLE"/>
+                    <munit:parameter propertyName="expectedModifiers" value="public static"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="ProcessingMessage">
+                <munit:parameters>
+                    <munit:parameter propertyName="className" value="com.github.fge.jsonschema.core.report.ProcessingMessage"/>
+                    <munit:parameter propertyName="memberName" value="BUNDLE"/>
+                    <munit:parameter propertyName="expectedModifiers" value="public static"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="MessageBundles">
+                <munit:parameters>
+                    <munit:parameter propertyName="className" value="com.github.fge.msgsimple.load.MessageBundles"/>
+                    <munit:parameter propertyName="memberName" value="BUNDLES"/>
+                    <munit:parameter propertyName="expectedModifiers" value="public static"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="MessageBundle">
+                <munit:parameters>
+                    <munit:parameter propertyName="className" value="com.github.fge.msgsimple.bundle.MessageBundle"/>
+                    <munit:parameter propertyName="memberName" value="providers"/>
+                    <munit:parameter propertyName="expectedModifiers" value="public"/>
+                </munit:parameters>
+            </munit:parameterization>
+            <munit:parameterization name="LoadingMessageSourceProvider">
+                <munit:parameters>
+                    <munit:parameter propertyName="className" value="com.github.fge.msgsimple.provider.LoadingMessageSourceProvider"/>
+                    <munit:parameter propertyName="memberName" value="service"/>
+                    <munit:parameter propertyName="expectedModifiers" value="public"/>
+                </munit:parameters>
+            </munit:parameterization>
+        </munit:parameterizations>
+    </munit:config>
+
+    <munit:test name="VerifyClassLoaderUsesConnectorDirectory" description="Ensures that the modified class is loaded">
+        <munit:validation>
+            <munit-tools:assert-that
+                    expression='#[
+%dw 2.0
+import invokeExactMethod from java!org::apache::commons::lang3::reflect::MethodUtils
+import getClassLoader from java!ClassUtils
+var artifactClassLoader = getClassLoader(app.registry."_muleClassLoaderRepository", "domain/default/app/${app.name}/plugin/${extensionName}")
+var classResource = invokeExactMethod(artifactClassLoader, "getResource", ["${shadePackage}.${className}" replace "." with ("/") ++ ".class"])
+ ---
+classResource.file
+                    ]'
+                    is='#[MunitTools::startsWith("file:${project.build.directory}")]'
+            />
+        </munit:validation>
+    </munit:test>
+    <munit:test name="VerifyClassMemberHasPublicModifiers" description="Ensures that the class member is public">
+        <munit:validation>
+            <munit-tools:assert-that
+                    expression='#[
+%dw 2.0
+import valueOf from java!java::lang::String
+import getDeclaredField from java!ClassUtils
+import getClassLoader from java!ClassUtils
+var artifactClassLoader = getClassLoader(app.registry."_muleClassLoaderRepository", "domain/default/app/${app.name}/plugin/${extensionName}")
+var memberObject = getDeclaredField(artifactClassLoader, "${shadePackage}.${className}", "${memberName}")
+var memberDefinition = valueOf(memberObject)
+ ---
+memberDefinition
+                    ]'
+                    is='#[MunitTools::startsWith("${expectedModifiers}")]'
+            />
+        </munit:validation>
+    </munit:test>
+</mule>


### PR DESCRIPTION
The main work comes from https://github.com/mulesoft/mule-json-module/pull/196 which addresses some Reflective Access issues for the Json Tools library.

To quickly catch up anyone reading this who hasn't been fully in the loop with https://github.com/mulesoft/mule-json-module/pull/196 : the short version is that the reflection usage in JSON module with regards to the JSON Tools library was definitely needed before, in order to access the private class members involved in working around the thread leak issue.

Since we wanted to avoid breaking backwards compatibility, which could have involved either replacing the library or deprecating the schema versions supported by the library, we had to come up with several proposals for changing how the library behaves without impacting the rest of the functionality.

We came up with a creative solution, which we also described in a [tech spec](https://docs.google.com/document/d/1Ub0ZELgbPgSzsVF7XdeL9hRhHa0SoZDxhmxWUFncwgU/edit#heading=h.gbqonn3wmdgy), where we modify the library classes at compile time during shading, making the class members that we need to change as public and non-final, right before the shader performs package relocation.

You can also see this behaviour being tested in [JsonToolsReflectiveAccessTestCase.xml](https://github.com/mulesoft/mule-json-module/blob/feature/jdk-17-validation/src/test/munit/JsonToolsReflectiveAccessTestCase.xml) where we load the shaded classes and make sure that the class members are public.

The reflective access test case plays an important role in making sure that the custom shader is always invoked during compilation and that the class members are compatible with the reflective access performed at runtime.