### PR TITLE
W-14775713 | Java 17 runtime compatibility changes release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-json-module</artifactId>
-    <version>2.5.0-SNAPSHOT</version>
+    <version>2.5.0</version>
     <packaging>mule-extension</packaging>
     <name>Json Module</name>
 

--- a/src/it/tita/src/test/resources/json-module-app-pom.xml
+++ b/src/it/tita/src/test/resources/json-module-app-pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <app.runtime>4.3.0</app.runtime>
         <mule.maven.plugin.version>3.3.5</mule.maven.plugin.version>
-        <mule.json.module.version>2.5.0-SNAPSHOT</mule.json.module.version>
+        <mule.json.module.version>2.5.0</mule.json.module.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Reflection usage in JSON module with regards to the JSON Tools library was needed before in order to access the private class members involved in working around the thread leak issue.

Since we wanted to avoid breaking backwards compatibility, which could have involved either replacing the library or deprecating the schema versions supported by the library, we had to come up with several proposals for changing how the library behaves without impacting the rest of the functionality.

We came up with a creative solution, which we also described in a [tech spec](https://docs.google.com/document/d/1Ub0ZELgbPgSzsVF7XdeL9hRhHa0SoZDxhmxWUFncwgU/edit#heading=h.gbqonn3wmdgy), where we modify the library classes at compile time during shading, making the class members that we need to change as public and non-final, right before the shader performs package relocation.

You can also see this behaviour being tested in [JsonToolsReflectiveAccessTestCase.xml](https://github.com/mulesoft/mule-json-module/blob/feature/jdk-17-validation/src/test/munit/JsonToolsReflectiveAccessTestCase.xml) where we load the shaded classes and make sure that the class members are public.

The reflective access test case plays an important role in making sure that the custom shader is always invoked during compilation and that the class members are compatible with the reflective access performed at runtime.